### PR TITLE
Add support for glam 0.21.0-0.22.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 memoffset = "0.7"
 speedy-derive = { version = "= 0.8.3", path = "speedy-derive", optional = true }
 chrono = { version = "0.4", optional = true }
-glam = { version = ">= 0.15, <= 0.20", optional = true }
+glam = { version = ">= 0.15, <= 0.22", optional = true }
 smallvec = { version = "1", optional = true }
 regex = { version = "1", optional = true, default-features = false }
 uuid = {version = "1", optional = true, default-features = false }


### PR DESCRIPTION
Just extends the version range, required to be able to be used with later available glam versions