### PR TITLE
Fix Clippy unsafe warnings that affects users

### DIFF
--- a/speedy-derive/src/lib.rs
+++ b/speedy-derive/src/lib.rs
@@ -2078,9 +2078,11 @@ fn impl_readable( input: syn::DeriveInput ) -> Result< TokenStream, syn::Error >
                     let name = field.name();
 
                     body_flip_endianness.push( quote! {
-                        <#ty as speedy::Readable< 'a_, C_ >>::speedy_flip_endianness(
-                            std::ptr::addr_of_mut!( (*itself).#name )
-                        );
+                        unsafe {
+                            <#ty as speedy::Readable< 'a_, C_ >>::speedy_flip_endianness(
+                                std::ptr::addr_of_mut!( (*itself).#name )
+                            );
+                        }
                     });
                 }
 
@@ -2098,7 +2100,7 @@ fn impl_readable( input: syn::DeriveInput ) -> Result< TokenStream, syn::Error >
                     }
 
                     #[inline(always)]
-                    fn speedy_flip_endianness( itself: *mut Self ) {
+                    unsafe fn speedy_flip_endianness( itself: *mut Self ) {
                         unsafe {
                             #(#body_flip_endianness)*
                         }
@@ -2108,7 +2110,9 @@ fn impl_readable( input: syn::DeriveInput ) -> Result< TokenStream, syn::Error >
                     fn speedy_convert_slice_endianness( endianness: speedy::Endianness, slice: &mut [Self] ) {
                         if endianness.conversion_necessary() {
                             for value in slice {
-                                <Self as speedy::Readable< 'a_, C_ >>::speedy_flip_endianness( value );
+                                unsafe {
+                                    <Self as speedy::Readable< 'a_, C_ >>::speedy_flip_endianness( value );
+                                }
                             }
                         }
                     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -87,7 +87,7 @@ pub fn get_error_kind( error: &Error ) -> &ErrorKind {
 }
 
 impl fmt::Display for Error {
-    fn fmt( &self, fmt: &mut fmt::Formatter ) -> fmt::Result {
+    fn fmt( &self, fmt: &mut fmt::Formatter<'_> ) -> fmt::Result {
         match self.kind {
             ErrorKind::InvalidChar => write!( fmt, "out of range char" ),
             ErrorKind::InvalidEnumVariant => write!( fmt, "invalid enum variant" ),

--- a/src/private.rs
+++ b/src/private.rs
@@ -41,7 +41,7 @@ pub fn vec_to_string< E >( bytes: Vec< u8 > ) -> Result< String, E > where E: Fr
 }
 
 #[inline]
-pub fn cow_bytes_to_cow_str< E >( bytes: Cow< [u8] > ) -> Result< Cow< str >, E > where E: From< Error > {
+pub fn cow_bytes_to_cow_str< E >( bytes: Cow<'_, [u8] > ) -> Result< Cow<'_, str >, E > where E: From< Error > {
     match bytes {
         Cow::Borrowed( bytes ) => {
             std::str::from_utf8( bytes )

--- a/src/readable.rs
+++ b/src/readable.rs
@@ -58,8 +58,10 @@ impl< 'a, C: Context > Reader< 'a, C > for BufferReader< 'a, C > {
             return Err( error_end_of_input() );
         }
 
-        std::ptr::copy_nonoverlapping( self.ptr, output, length );
-        self.ptr = self.ptr.add( length );
+        unsafe { 
+            std::ptr::copy_nonoverlapping( self.ptr, output, length );
+            self.ptr = self.ptr.add( length );
+        }
 
         Ok(())
     }
@@ -84,7 +86,9 @@ impl< 'a, C: Context > Reader< 'a, C > for BufferReader< 'a, C > {
             return Err( error_end_of_input() );
         }
 
-        std::ptr::copy_nonoverlapping( self.ptr, output, length );
+        unsafe {
+            std::ptr::copy_nonoverlapping( self.ptr, output, length );
+        }
         Ok(())
     }
 
@@ -199,8 +203,10 @@ impl< 'ctx, 'r, 'a, C: Context > Reader< 'r, C > for CopyingBufferReader< 'ctx, 
             return Err( error_end_of_input() );
         }
 
-        std::ptr::copy_nonoverlapping( self.ptr, output, length );
-        self.ptr = self.ptr.add( length );
+        unsafe {
+            std::ptr::copy_nonoverlapping( self.ptr, output, length );
+            self.ptr = self.ptr.add( length );
+        }
 
         Ok(())
     }
@@ -225,7 +231,9 @@ impl< 'ctx, 'r, 'a, C: Context > Reader< 'r, C > for CopyingBufferReader< 'ctx, 
             return Err( error_end_of_input() );
         }
 
-        std::ptr::copy_nonoverlapping( self.ptr, output, length );
+        unsafe {
+            std::ptr::copy_nonoverlapping( self.ptr, output, length );
+        }
         Ok(())
     }
 
@@ -645,7 +653,7 @@ pub trait Readable< 'a, C: Context >: Sized {
 
     #[doc(hidden)]
     #[inline]
-    fn speedy_flip_endianness( _: *mut Self ) {
+    unsafe fn speedy_flip_endianness( _: *mut Self ) {
         panic!();
     }
 

--- a/src/readable_impl.rs
+++ b/src/readable_impl.rs
@@ -131,12 +131,14 @@ macro_rules! impl_for_primitive {
             #[doc(hidden)]
             #[inline]
             unsafe fn speedy_slice_from_bytes( slice: &[u8] ) -> &[Self] {
-                std::slice::from_raw_parts( slice.as_ptr() as *const $type, slice.len() / mem::size_of::< Self >() )
+                unsafe {
+                    std::slice::from_raw_parts( slice.as_ptr() as *const $type, slice.len() / mem::size_of::< Self >() )
+                }
             }
 
             #[doc(hidden)]
             #[inline(always)]
-            fn speedy_flip_endianness( itself: *mut Self ) {
+            unsafe fn speedy_flip_endianness( itself: *mut Self ) {
                 unsafe {
                     std::ptr::write_unaligned( itself, std::ptr::read_unaligned( itself ).swap_bytes() );
                 }

--- a/src/readable_unsized_impl.rs
+++ b/src/readable_unsized_impl.rs
@@ -45,7 +45,9 @@ impl< 'a, C: Context, T > Readable< 'a, C > for &'a [T] where T: crate::utils::Z
 
 #[inline(always)]
 unsafe fn cast_slice< T, const N: usize >( slice: &[u8] ) -> &[T; N] {
-    &*(slice.as_ptr() as *const [T; N])
+    unsafe {
+        &*(slice.as_ptr() as *const [T; N])
+    }
 }
 
 impl< 'a, C: Context, T, const N: usize > Readable< 'a, C > for &'a [T; N] where T: crate::utils::ZeroCopyable< T > {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -55,12 +55,16 @@ pub trait Reader< 'a, C: Context >: Sized {
 
     #[inline(always)]
     unsafe fn read_bytes_into_ptr( &mut self, output: *mut u8, length: usize ) -> Result< (), C::Error > {
-        self.read_bytes( std::slice::from_raw_parts_mut( output, length ) )
+        unsafe {
+            self.read_bytes( std::slice::from_raw_parts_mut( output, length ) )
+        }
     }
 
     #[inline(always)]
     unsafe fn peek_bytes_into_ptr( &mut self, output: *mut u8, length: usize ) -> Result< (), C::Error > {
-        self.peek_bytes( std::slice::from_raw_parts_mut( output, length ) )
+        unsafe {
+            self.peek_bytes( std::slice::from_raw_parts_mut( output, length ) )
+        }
     }
 
     #[inline(always)]

--- a/src/writable_impl.rs
+++ b/src/writable_impl.rs
@@ -128,7 +128,9 @@ macro_rules! impl_for_primitive {
             #[doc(hidden)]
             #[inline(always)]
             unsafe fn speedy_slice_as_bytes( slice: &[Self] ) -> &[u8] where Self: Sized {
-                std::slice::from_raw_parts( slice.as_ptr() as *const u8, slice.len() * mem::size_of::< Self >() )
+                unsafe {
+                    std::slice::from_raw_parts( slice.as_ptr() as *const u8, slice.len() * mem::size_of::< Self >() )
+                }
             }
         }
     }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -77,14 +77,12 @@ pub trait Writer< C: Context > {
 
     #[inline(always)]
     fn write_f32( &mut self, value: f32 ) -> Result< (), C::Error > {
-        let value: u32 = unsafe { mem::transmute( value ) };
-        self.write_u32( value )
+        self.write_u32( value.to_bits() )
     }
 
     #[inline(always)]
-    fn write_f64( &mut self, value: f64 ) -> Result< (), C::Error > {
-        let value: u64 = unsafe { mem::transmute( value ) };
-        self.write_u64( value )
+    fn write_f64( &mut self, value: f64 ) -> Result< (), C::Error > {        
+        self.write_u64( value.to_bits() )
     }
 
     #[inline(always)]


### PR DESCRIPTION
The proc macro that generates code was generating major Clippy lint warnings for users for the crate, which is hard to work around as every call-site has to have `#[allow(clippy::xxx)]`.

This fixes the main Clippy warning in this crate instead, and should be no functional changes. 

Here is how the warnings looked like for a user of the crate with the latest version:

```
error: this public function might dereference a raw pointer but is not marked `unsafe`
  --> api/api/src/api/resource.rs:82:62
   |
82 | #[cfg_attr(feature = "with_speedy", derive(speedy::Writable, speedy::Readable))]
   |                                                              ^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref
   = note: this error originates in the derive macro `speedy::Readable` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Would be fantastic to fix the rest also and enable Clippy in CI as well, but that can be done as a separate change.

Here is an example of Clippy warnings this resolves (though I think there were a few more):

```
warning: transmute from a `f64` to a `u64`
  --> src/writer.rs:86:35
   |
86 |         let value: u64 = unsafe { mem::transmute( value ) };
   |                                   ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `value.to_bits()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#transmute_float_to_int


    error: this public function might dereference a raw pointer but is not marked `unsafe`
    --> src/readable_impl.rs:141:82
     |
 141 |                     std::ptr::write_unaligned( itself, std::ptr::read_unaligned( itself ).swap_bytes() );
     |                                                                                  ^^^^^^
 ...
 165 | impl_for_primitive!( f64, read_f64, swap_slice_f64 );
     | ---------------------------------------------------- in this macro invocation
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref
     = note: this error originates in the macro `impl_for_primitive` (in Nightly builds, run with -Z macro-backtrace for more info)

 warning: this lifetime isn't used in the impl
   --> src/readable.rs:282:7
    |
282 | impl< 'a, C, S > StreamReader< C, S > where C: Context, S: Read {
    |       ^^
    |
    = note: `#[warn(clippy::extra_unused_lifetimes)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_lifetimes
```