### PR TITLE
Adds Readable and Writable implementations for RangeInclusive

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Out-of-box the following types are supported:
 |            `HashSet<T>` |             `{length: u32, values: [T]}` |
 |           `BTreeSet<T>` |             `{length: u32, values: [T]}` |
 |              `Range<T>` |                                 `(T, T)` |
+|     `RangeInclusive<T>` |                                 `(T, T)` |
 |             `Option<T>` |                    `(1_u8, T)` or `0_u8` |
 |          `Result<T, E>` |               `(1_u8, T)` or `(0_u8, E)` |
 |                    `()` |                                  nothing |

--- a/src/readable_impl.rs
+++ b/src/readable_impl.rs
@@ -1,6 +1,6 @@
 use std::mem;
 use std::borrow::{Cow, ToOwned};
-use std::ops::Range;
+use std::ops::{Range, RangeInclusive};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::hash::{BuildHasher, Hash};
 
@@ -291,6 +291,20 @@ impl< 'a, C: Context, T: Readable< 'a, C > > Readable< 'a, C > for Range< T > {
         let start = reader.read_value()?;
         let end = reader.read_value()?;
         Ok( start..end )
+    }
+
+    #[inline]
+    fn minimum_bytes_needed() -> usize {
+        <T as Readable< 'a, C >>::minimum_bytes_needed() * 2
+    }
+}
+
+impl< 'a, C: Context, T: Readable< 'a, C > > Readable< 'a, C > for RangeInclusive< T > {
+    #[inline]
+    fn read_from< R: Reader< 'a, C > >( reader: &mut R ) -> Result< Self, C::Error > {
+        let start = reader.read_value()?;
+        let end = reader.read_value()?;
+        Ok( start..=end )
     }
 
     #[inline]

--- a/src/writable_impl.rs
+++ b/src/writable_impl.rs
@@ -1,6 +1,6 @@
 use std::mem;
 use std::borrow::{Cow, ToOwned};
-use std::ops::Range;
+use std::ops::{Range, RangeInclusive};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::hash::Hash;
 
@@ -351,6 +351,19 @@ impl< C: Context, T: Writable< C > > Writable< C > for Range< T > {
     #[inline]
     fn bytes_needed( &self ) -> Result< usize, C::Error > {
         Ok( Writable::< C >::bytes_needed( &self.start )? + Writable::< C >::bytes_needed( &self.end )? )
+    }
+}
+
+impl< C: Context, T: Writable< C > > Writable< C > for RangeInclusive< T > {
+    #[inline]
+    fn write_to< W: ?Sized + Writer< C > >( &self, writer: &mut W ) -> Result< (), C::Error > {
+        self.start().write_to( writer )?;
+        self.end().write_to( writer )
+    }
+
+    #[inline]
+    fn bytes_needed( &self ) -> Result< usize, C::Error > {
+        Ok( Writable::< C >::bytes_needed( self.start() )? + Writable::< C >::bytes_needed( self.end() )? )
     }
 }
 

--- a/tests/serialization_tests.rs
+++ b/tests/serialization_tests.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::ops::Range;
+use std::ops::{Range, RangeInclusive};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::Debug;
 use std::num::NonZeroU32;
@@ -1313,6 +1313,12 @@ symmetric_tests! {
     }
     range_u16 for Range< u16 > {
         in = 10..11,
+        le = [10, 0, 11, 0],
+        be = [0, 10, 0, 11],
+        minimum_bytes = 4
+    }
+    range_inc_u16 for RangeInclusive< u16 > {
+        in = 10..=11,
         le = [10, 0, 11, 0],
         be = [0, 10, 0, 11],
         minimum_bytes = 4


### PR DESCRIPTION
Mostly a copy/paste from the implementations on `Range`.