### PR TITLE
feat: Added serialization for Chrono Duration

### DIFF
--- a/src/ext_chrono.rs
+++ b/src/ext_chrono.rs
@@ -2,7 +2,8 @@ use {
     chrono::{
         DateTime,
         TimeZone,
-        Utc
+        Utc,
+        Duration
     },
     crate::{
         Context,
@@ -37,6 +38,39 @@ impl< C > Writable< C > for DateTime< Utc >
     fn write_to< T: ?Sized + Writer< C > >( &self, writer: &mut T ) -> Result< (), C::Error > {
         writer.write_i64( self.timestamp() )?;
         writer.write_u32( self.timestamp_subsec_nanos() )
+    }
+
+    #[inline]
+    fn bytes_needed( &self ) -> Result< usize, C::Error > {
+        Ok( 12 )
+    }
+}
+
+
+impl< 'a, C > Readable< 'a, C > for Duration
+where C: Context
+{
+    #[inline]
+    fn read_from< R: Reader< 'a, C > >( reader: &mut R ) -> Result< Self, C::Error > {
+        let seconds = reader.read_i64()?;
+        let subsec_nanos = reader.read_u32()?;
+        Ok( Duration::new(seconds, subsec_nanos).unwrap() )
+    }
+
+    #[inline]
+    fn minimum_bytes_needed() -> usize {
+        12
+    }
+}
+
+
+impl< C > Writable< C > for Duration
+where C: Context
+{
+    #[inline]
+    fn write_to< T: ?Sized + Writer< C > >( &self, writer: &mut T ) -> Result< (), C::Error > {
+        writer.write_i64( self.num_seconds() )?;
+        writer.write_u32( self.subsec_nanos() as u32 )
     }
 
     #[inline]

--- a/tests/serialization_tests.rs
+++ b/tests/serialization_tests.rs
@@ -2298,6 +2298,13 @@ symmetric_tests! {
         be = [0, 0, 0, 0, 0, 0, 0, 123, 0, 0, 0, 222],
         minimum_bytes = 12
     }
+
+    chrono_duration for chrono::Duration {
+        in = chrono::Duration::new(321, 169).unwrap(),
+        le = [65, 1, 0, 0, 0, 0, 0, 0, 169, 0, 0, 0],
+        be = [0, 0, 0, 0, 0, 0, 1, 65, 0, 0, 0, 169],
+        minimum_bytes = 12
+    }
 }
 
 #[cfg(feature = "smallvec")]


### PR DESCRIPTION
## Context
- `chrono::Duration` is often used together with `chrono::DateTime`, so it might be reasonable to add support for `Duration` class as well

## Changes
- Add binary serde support for `chrono::Duration` when `chrono` feature is enabled.