### PR TITLE
Fix `clippy::legacy_numeric_constants` lints

### DIFF
--- a/speedy-derive/src/lib.rs
+++ b/speedy-derive/src/lib.rs
@@ -1,7 +1,6 @@
 #![recursion_limit="128"]
 
 use std::collections::HashMap;
-use std::u32;
 
 extern crate proc_macro;
 extern crate proc_macro2;
@@ -1863,11 +1862,11 @@ impl< 'a > Enum< 'a > {
         let tag_type = attrs.tag_type.unwrap_or( DEFAULT_ENUM_TAG_TYPE );
         let max = match tag_type {
             BasicType::U7 => 0b01111111 as u64,
-            BasicType::U8 => core::u8::MAX as u64,
-            BasicType::U16 => core::u16::MAX as u64,
-            BasicType::U32 => core::u32::MAX as u64,
-            BasicType::U64 => core::u64::MAX,
-            BasicType::VarInt64 => core::u64::MAX
+            BasicType::U8 => u8::MAX as u64,
+            BasicType::U16 => u16::MAX as u64,
+            BasicType::U32 => u32::MAX as u64,
+            BasicType::U64 => u64::MAX,
+            BasicType::VarInt64 => u64::MAX
         };
 
         let mut previous_tag = None;

--- a/src/private.rs
+++ b/src/private.rs
@@ -76,7 +76,7 @@ pub fn write_length_u32< C, W >( length: usize, writer: &mut W ) -> Result< (), 
     where C: Context,
           W: ?Sized + Writer< C >
 {
-    if length as u64 > core::u32::MAX as u64 {
+    if length as u64 > u32::MAX as u64 {
          return Err( error_out_of_range_length() );
     }
 
@@ -88,7 +88,7 @@ pub fn write_length_u16< C, W >( length: usize, writer: &mut W ) -> Result< (), 
     where C: Context,
           W: ?Sized + Writer< C >
 {
-    if length as u64 > core::u16::MAX as u64 {
+    if length as u64 > u16::MAX as u64 {
          return Err( error_out_of_range_length() );
     }
 
@@ -100,7 +100,7 @@ pub fn write_length_u8< C, W >( length: usize, writer: &mut W ) -> Result< (), C
     where C: Context,
           W: ?Sized + Writer< C >
 {
-    if length as u64 > core::u8::MAX as u64 {
+    if length as u64 > u8::MAX as u64 {
          return Err( error_out_of_range_length() );
     }
 
@@ -133,7 +133,7 @@ pub fn read_length_u64_varint< 'a, C, R >( reader: &mut R ) -> Result< usize, C:
           R: Reader< 'a, C >
 {
     let length: u64 = VarInt64::read_from( reader )?.into();
-    if length > core::usize::MAX as u64 {
+    if length > usize::MAX as u64 {
         return Err( error_out_of_range_length() );
     }
 
@@ -146,7 +146,7 @@ pub fn read_length_u64< 'a, C, R >( reader: &mut R ) -> Result< usize, C::Error 
           R: Reader< 'a, C >
 {
     let length = reader.read_u64()?;
-    if length > core::usize::MAX as u64 {
+    if length > usize::MAX as u64 {
         return Err( error_out_of_range_length() );
     }
 

--- a/src/readable_impl.rs
+++ b/src/readable_impl.rs
@@ -187,7 +187,7 @@ impl< 'a, C: Context > Readable< 'a, C > for usize {
     #[inline]
     fn read_from< R: Reader< 'a, C > >( reader: &mut R ) -> Result< Self, C::Error > {
         let value = u64::read_from( reader )?;
-        if value > core::usize::MAX as u64 {
+        if value > usize::MAX as u64 {
             return Err( crate::error::error_too_big_usize_for_this_architecture() );
         }
         Ok( value as usize )


### PR DESCRIPTION
These are marked that they will be deprecated in the future.