### PR TITLE
Fix #79 - avoid UB when writing lots of ZST's

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,4 @@
+// Assumes each item occupies at least 1 byte, so do not use for ZST's.
 macro_rules! unsafe_is_length {
     ($expr:expr) => {
         if $expr as u64 >= 0x7FFFFFFF_FFFFFFFF {

--- a/src/writable_impl.rs
+++ b/src/writable_impl.rs
@@ -260,7 +260,7 @@ impl< C: Context, T: Writable< C > > Writable< C > for [T] {
 
     #[inline]
     fn bytes_needed( &self ) -> Result< usize, C::Error > {
-        if core::mem::size_of::<T>() > 0 {
+        if mem::size_of::<T>() > 0 {
             unsafe_is_length!( self.len() );
         }
 

--- a/src/writable_impl.rs
+++ b/src/writable_impl.rs
@@ -260,7 +260,9 @@ impl< C: Context, T: Writable< C > > Writable< C > for [T] {
 
     #[inline]
     fn bytes_needed( &self ) -> Result< usize, C::Error > {
-        unsafe_is_length!( self.len() );
+        if core::mem::size_of::<T>() > 0 {
+            unsafe_is_length!( self.len() );
+        }
 
         if T::speedy_is_primitive() {
             return Ok( 4 + self.len() * mem::size_of::< T >() );


### PR DESCRIPTION
Fixes #79

Technically the issue also affects `{Hash, BTree}{Map, Set}` but having more than `0x7FFFFFFF_FFFFFFFF` ZST's with *different* hash values or different comparisons seems difficult to do by accident.

I would add a test but this is impractical to test in debug mode and/or Miri, because it's too slow. Testing in release mode would work, but that wouldn't catch the original UB.